### PR TITLE
Create group for leavers which can deny API access

### DIFF
--- a/terraform/groups.tf
+++ b/terraform/groups.tf
@@ -19,3 +19,12 @@ resource "aws_iam_group_policy_attachment" "administrators-policy" {
     group = "${aws_iam_group.administrators.name}"
     policy_arn = "arn:aws:iam::aws:policy/IAMFullAccess"
 }
+
+resource "aws_iam_group" "leavers" {
+  name = "Leavers"
+}
+
+resource "aws_iam_group_policy_attachment" "leavers_deny_all" {
+  group = "${aws_iam_group.leavers.name}"
+  policy_arn = "${aws_iam_policy.deny_all.arn}"
+}

--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -96,3 +96,22 @@ resource "aws_iam_policy" "self_manage_iam_user" {
     description = "Allows the user to manage their own credentials and list all users"
     policy = "${data.aws_iam_policy_document.self_manage_iam_user.json}"
 }
+
+data "aws_iam_policy_document" "deny_all" {
+  statement {
+    sid = "DenyAllAPIAccess"
+    effect = "Deny"
+    actions = [
+      "*:*",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "deny_all" {
+  name = "deny_all"
+  description = "Disallows all calls to AWS APIs"
+  policy = "${data.aws_iam_policy_document.deny_all.json}"
+}


### PR DESCRIPTION
Rather than deleting user accounts as they leave we apply a "soft delete" and
move them into an IAM Group which denies any AWS API calls.

This helps mitigate new joiners with the same username inheriting some
permissions from cross-account assume role trust policies. AWS mitigates this by
transforming usernames into principal IDs[0] but this is undone when an assume
role policy is modified.

[0] See the "Important" section of "Creating a Role (AWS CLI)"
   http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user.html