### PR TITLE
Add a password policy for the account

### DIFF
--- a/terraform/password_policy.tf
+++ b/terraform/password_policy.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_account_password_policy" "base_account_password_policy" {
+    minimum_password_length        = 20
+    require_lowercase_characters   = true
+    require_numbers                = true
+    require_uppercase_characters   = true
+    allow_users_to_change_password = true
+}


### PR DESCRIPTION
This sets restrictions on users' passwords. Since we'll be using the users in
this account across all our other accounts eventually, we should set
reasonable restrictions on passwords from the start.

The self-manage-iam-user policy already allows users to see this password
policy.