### PR TITLE
Update password policy to min length 16

### DIFF
--- a/terraform/password_policy.tf
+++ b/terraform/password_policy.tf
@@ -1,7 +1,4 @@
-resource "aws_iam_account_password_policy" "base_account_password_policy" {
-    minimum_password_length        = 20
-    require_lowercase_characters   = true
-    require_numbers                = true
-    require_uppercase_characters   = true
+resource "aws_iam_account_password_policy" "password_policy" {
+    minimum_password_length        = 16
     allow_users_to_change_password = true
 }


### PR DESCRIPTION
We have raised an issue with AWS to follow (or rather, add features allowing us
to follow) the password guidance from NCSC:

  https://www.ncsc.gov.uk/guidance/password-guidance-simplifying-your-approach

AWS doesn't communicate the password policy to users when changing password
which makes the complexity rules particularly unpleasant.

Until then we should follow what we can and remove the complexity requirements
and lower the minimum length.