### PR TITLE
Remove Unauthorized Activity alarm

### DIFF
--- a/terraform/cloudwatch-alarms.tf
+++ b/terraform/cloudwatch-alarms.tf
@@ -18,10 +18,3 @@ module "root_activity" {
   alarm_actions        = ["${module.aws_security_alarms.security_alerts_topic}"]
   environment_name     = "${var.environment_name}"
 }
-
-module "unauthorized_activity" {
-  source               = "github.com/alphagov/aws-security-alarms/terraform/alarms/unauthorized_activity"
-  cloudtrail_log_group = "${module.aws_security_alarms.cloudtrail_log_group}"
-  alarm_actions        = ["${module.aws_security_alarms.security_alerts_topic}"]
-  environment_name     = "${var.environment_name}"
-}


### PR DESCRIPTION
Most users of this account only have minimal permissions allowed in the
cross-account-access IAM Group. When these users sign in with the AWS Console
they frequently trigger unauthorized access alarms accidentally, it's very easy
to do so when switching Roles.

For now we'll remove this alarm and only leave the alarm for Root user activity.