### PR TITLE
Stop having errors in default user flow

### DIFF
--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -25,6 +25,10 @@ data "aws_iam_policy_document" "self_manage_iam_user" {
     effect = "Allow"
 
     actions = [
+      "iam:GetUser",
+      "iam:ListUserPolicies",
+      "iam:ListAttachedUserPolicies",
+      "iam:ListGroupsForUser",
       "iam:*LoginProfile",
       "iam:*AccessKey*",
       "iam:*SSHPublicKey*",
@@ -43,6 +47,9 @@ data "aws_iam_policy_document" "self_manage_iam_user" {
       "iam:GetAccountSummary",
       "iam:GetAccountPasswordPolicy",
       "iam:ListUsers",
+      "iam:ListGroups",
+      "iam:ListGroupPolicies",
+      "iam:ListAttachedGroupPolicies",
     ]
 
     resources = [

--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -1,98 +1,112 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "assume_any_role" {
-    statement {
-        effect = "Allow"
-        actions = [
-            "sts:AssumeRole",
-        ]
-        resources = [
-            "*",
-        ]
-    }
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "assume_any_role" {
-    name = "assume_any_role"
-    description = "Allows the user to call sts:AssumeRole on anything"
-    policy = "${data.aws_iam_policy_document.assume_any_role.json}"
+  name        = "assume_any_role"
+  description = "Allows the user to call sts:AssumeRole on anything"
+  policy      = "${data.aws_iam_policy_document.assume_any_role.json}"
 }
 
 data "aws_iam_policy_document" "self_manage_iam_user" {
-    statement {
-        effect = "Allow"
-        actions = [
-            "iam:*LoginProfile",
-            "iam:*AccessKey*",
-            "iam:*SSHPublicKey*"
-        ]
-        resources = [
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
-        ]
-    }
+  statement {
+    effect = "Allow"
 
-    statement {
-        effect = "Allow"
-        actions = [
-            "iam:ListAccount*",
-            "iam:GetAccountSummary",
-            "iam:GetAccountPasswordPolicy",
-            "iam:ListUsers"
-        ]
-        resources = [
-            "*",
-        ]
-    }
+    actions = [
+      "iam:*LoginProfile",
+      "iam:*AccessKey*",
+      "iam:*SSHPublicKey*",
+    ]
 
-    statement {
-        sid = "AllowUsersToCreateEnableResyncDeleteTheirOwnVirtualMFADevice"
-        effect = "Allow"
-        actions = [
-            "iam:CreateVirtualMFADevice",
-            "iam:EnableMFADevice",
-            "iam:ResyncMFADevice",
-            "iam:DeleteVirtualMFADevice"
-        ]
-        resources = [
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}"
-        ]
-    }
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
+    ]
+  }
 
-    statement = {
-        sid = "RequireMFAWhenUsersDeactivateTheirOwnVirtualMFADevice"
-        effect = "Allow"
-        actions = [
-            "iam:DeactivateMFADevice"
-        ]
-        resources = [
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}"
-        ]
-        condition {
-            test = "Bool"
-            variable = "aws:MultiFactorAuthPresent"
-            values = [
-                "true",
-            ]
-        }
-    }
+  statement {
+    effect = "Allow"
 
-    statement {
-        sid = "AllowUsersToListMFADevicesandUsersForConsole"
-        effect = "Allow"
-        actions = [
-            "iam:ListMFADevices",
-            "iam:ListVirtualMFADevices"
-        ]
-        resources = [
-            "*",
-        ]
+    actions = [
+      "iam:ListAccount*",
+      "iam:GetAccountSummary",
+      "iam:GetAccountPasswordPolicy",
+      "iam:ListUsers",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid    = "AllowUsersToCreateEnableResyncDeleteTheirOwnVirtualMFADevice"
+    effect = "Allow"
+
+    actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:EnableMFADevice",
+      "iam:ResyncMFADevice",
+      "iam:DeleteVirtualMFADevice",
+    ]
+
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
+    ]
+  }
+
+  statement = {
+    sid    = "RequireMFAWhenUsersDeactivateTheirOwnVirtualMFADevice"
+    effect = "Allow"
+
+    actions = [
+      "iam:DeactivateMFADevice",
+    ]
+
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+
+      values = [
+        "true",
+      ]
     }
+  }
+
+  statement {
+    sid    = "AllowUsersToListMFADevicesandUsersForConsole"
+    effect = "Allow"
+
+    actions = [
+      "iam:ListMFADevices",
+      "iam:ListVirtualMFADevices",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "self_manage_iam_user" {
-    name = "self_manage_iam_user"
-    description = "Allows the user to manage their own credentials and list all users"
-    policy = "${data.aws_iam_policy_document.self_manage_iam_user.json}"
+  name        = "self_manage_iam_user"
+  description = "Allows the user to manage their own credentials and list all users"
+  policy      = "${data.aws_iam_policy_document.self_manage_iam_user.json}"
 }


### PR DESCRIPTION
If you view your own IAM User in the console at the moment, you get
errors such as:

    You need permissions
    You do not have the permission required to perform this operation. Ask your administrator to add permissions. Learn more
    User: arn:aws:iam::622626885786:user/philip.potter@digital.cabinet-office.gov.uk is not authorized to perform: iam:GetUser on resource: user philip.potter@digital.cabinet-office.gov.uk

Currently, if a user wants to add or update their MFA credentials,
they have to know that they can ignore this error and just click on
the tab to update security credentials.

This is confusing.  We should have a service which doesn't ask users
to ignore errors.

I worked out that this is the set of permissions which makes the page
work.

In principle we could be more restrictive - eg we could restrict users
to only view group policies for groups they are a member of - but this
is a public repo anyway so I think that's overkill.

(This PR splits the `terraform fmt` and the substantive code changes, so it's worth viewing commit-by-commit)