### PR TITLE
Remove administrators group

### DIFF
--- a/terraform/groups.tf
+++ b/terraform/groups.tf
@@ -11,12 +11,3 @@ resource "aws_iam_group_policy_attachment" "cross-account-attach-assume-role" {
   group      = "${aws_iam_group.cross-account-access.name}"
   policy_arn = "${aws_iam_policy.assume_any_role.arn}"
 }
-
-resource "aws_iam_group" "administrators" {
-  name = "Administrators"
-}
-
-resource "aws_iam_group_policy_attachment" "administrators-policy" {
-  group      = "${aws_iam_group.administrators.name}"
-  policy_arn = "arn:aws:iam::aws:policy/IAMFullAccess"
-}

--- a/terraform/groups.tf
+++ b/terraform/groups.tf
@@ -1,21 +1,22 @@
 resource "aws_iam_group" "cross-account-access" {
-    name = "CrossAccountAccess"
+  name = "CrossAccountAccess"
 }
 
 resource "aws_iam_group_policy_attachment" "cross-account-attach-self-manage" {
-    group = "${aws_iam_group.cross-account-access.name}"
-    policy_arn = "${aws_iam_policy.self_manage_iam_user.arn}"
+  group      = "${aws_iam_group.cross-account-access.name}"
+  policy_arn = "${aws_iam_policy.self_manage_iam_user.arn}"
 }
+
 resource "aws_iam_group_policy_attachment" "cross-account-attach-assume-role" {
-    group = "${aws_iam_group.cross-account-access.name}"
-    policy_arn = "${aws_iam_policy.assume_any_role.arn}"
+  group      = "${aws_iam_group.cross-account-access.name}"
+  policy_arn = "${aws_iam_policy.assume_any_role.arn}"
 }
 
 resource "aws_iam_group" "administrators" {
-    name = "Administrators"
+  name = "Administrators"
 }
 
 resource "aws_iam_group_policy_attachment" "administrators-policy" {
-    group = "${aws_iam_group.administrators.name}"
-    policy_arn = "arn:aws:iam::aws:policy/IAMFullAccess"
+  group      = "${aws_iam_group.administrators.name}"
+  policy_arn = "arn:aws:iam::aws:policy/IAMFullAccess"
 }


### PR DESCRIPTION
This group had already been removed manually, so this change just
updates the terraform to reflect reality.

Also, we've decided that people should only perform admin privileges
when they have actively decided to assume and administrative role, and
not have those powers ambiently via group membership.