### PR TITLE
reduce password length policy to 15

### DIFF
--- a/terraform/password_policy.tf
+++ b/terraform/password_policy.tf
@@ -1,4 +1,4 @@
 resource "aws_iam_account_password_policy" "password_policy" {
-    minimum_password_length        = 16
-    allow_users_to_change_password = true
+  minimum_password_length        = 15
+  allow_users_to_change_password = true
 }


### PR DESCRIPTION
Chrome seems to suggest strong passwords that are 15 characters long.

If the password you try doesn't meet the password policy, you get an
error message with AWS's characteristic commitment to UX.  It says
something like "either the user doesn't have permission to
iam:ChangePassword, or the password doesn't meet the account's
password policy".  There is no feedback on what aspect of the policy
was not met.