### PR TITLE
Change self_manage_iam_user IAM policy to allow multiple MFA devices

### DIFF
--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -58,18 +58,29 @@ data "aws_iam_policy_document" "self_manage_iam_user" {
   }
 
   statement {
-    sid    = "AllowUsersToCreateEnableResyncDeleteTheirOwnVirtualMFADevice"
+    sid    = "AllowUsersToCreateMFADevices"
     effect = "Allow"
 
     actions = [
       "iam:CreateVirtualMFADevice",
-      "iam:EnableMFADevice",
-      "iam:ResyncMFADevice",
-      "iam:DeleteVirtualMFADevice",
     ]
 
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/*",
+    ]
+  }
+
+  statement {
+    sid    = "AllowUsersToEnableResyncTheirOwnVirtualMFADevice"
+    effect = "Allow"
+
+    actions = [
+      "iam:EnableMFADevice",
+      "iam:ResyncMFADevice",
+    ]
+
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/*",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
     ]
   }
@@ -83,7 +94,7 @@ data "aws_iam_policy_document" "self_manage_iam_user" {
     ]
 
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/*",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
     ]
 


### PR DESCRIPTION
In November 2022 AWS made a change to allow adding up to 8 MFA devices to an IAM user[1]. The `self_manage_iam_user` IAM policy does not support this, however, because it only allows a single MFA device ARN, where the device name is the IAM username. For the gds-users account this is the user's email address.

The IAM console allows the user to set a freeform name when adding an MFA device. Unless this matches the user's IAM username this results in an IAM error and confusion.

Allow the creation of MFA devices with freeform names in the gds-users account. Split the `iam:CreateVirtualMFADevice` action into a separate statement to make it clear it only applies to the MFA device and not a specific IAM user.

Allow users to enable and resync any MFA device in the gds-users account on their own IAM user.

Drop the `iam:DeleteVirtualMFADevice` action entirely because it is no longer possible to allow users to delete MFA devices without also allowing them to delete _all_ MFA devices in the account. Note this means users will need to ask an admin to delete MFA devices for them, which is not ideal but unavoidable without a way of tying an MFA device to a specific user.

Allow users to deactivate any MFA device in the gds-users account from their own IAM user as long as MFA is present in the current session.

1. https://aws.amazon.com/about-aws/whats-new/2022/11/aws-identity-access-management-multi-factor-authentication-devices/
2. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html