### PR TITLE
Change self_manage_iam_user IAM policy to allow multiple MFA devices

### DIFF
--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -58,18 +58,29 @@ data "aws_iam_policy_document" "self_manage_iam_user" {
   }
 
   statement {
-    sid    = "AllowUsersToCreateEnableResyncDeleteTheirOwnVirtualMFADevice"
+    sid    = "AllowUsersToCreateAndDeleteMFADevices"
     effect = "Allow"
 
     actions = [
       "iam:CreateVirtualMFADevice",
-      "iam:EnableMFADevice",
-      "iam:ResyncMFADevice",
       "iam:DeleteVirtualMFADevice",
     ]
 
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}*",
+    ]
+  }
+
+  statement {
+    sid    = "AllowUsersToEnableAndResyncTheirOwnVirtualMFADevice"
+    effect = "Allow"
+
+    actions = [
+      "iam:EnableMFADevice",
+      "iam:ResyncMFADevice",
+    ]
+
+    resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
     ]
   }
@@ -83,7 +94,6 @@ data "aws_iam_policy_document" "self_manage_iam_user" {
     ]
 
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
     ]
 


### PR DESCRIPTION
In November 2022 AWS made a change to allow adding up to 8 MFA devices to an IAM user[1]. The `self_manage_iam_user` IAM policy does not support this, however, because it only allows a single MFA device ARN, where the device name is the IAM username. For the gds-users account this is the user's email address.

The IAM console allows the user to set a freeform name when adding an MFA device. Unless this matches the user's IAM username this results in an IAM error and confusion.

We can't allow users to create MFA devices with freeform names because we cannot then write an IAM policy that allows the user to delete the device without also allowing them to delete other users' MFA devices. It will also make it difficult to work out who created an MFA device as there won't be any reference to the user in the device ARN.

Instead, allow users to create and delete MFA devices with names prefixed with their username (i.e. their email address). This will allow the creation of multiple MFA devices with a common prefix.

Split the `iam:CreateVirtualMFADevice` and `iam:DeleteVirtualMFADevice` actions into a separate statement to make it clear they only apply to the MFA device and not a specific IAM user.

Allow users to enable and resync any MFA device on their own IAM user. Remove the MFA device resource from the statement as it is not relevant for these actions.

Allow users to deactivate any MFA device from their own IAM user as long as MFA is present in the current session.

This supersedes https://github.com/alphagov/aws-user-management-account/pull/16

1. https://aws.amazon.com/about-aws/whats-new/2022/11/aws-identity-access-management-multi-factor-authentication-devices/
2. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html