### PR TITLE
Add "GetMFADevice" IAM action to self_manage_iam_user policy

### DIFF
--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -77,6 +77,7 @@ data "aws_iam_policy_document" "self_manage_iam_user" {
 
     actions = [
       "iam:EnableMFADevice",
+      "iam:GetMFADevice",
       "iam:ResyncMFADevice",
     ]
 


### PR DESCRIPTION
Users are seeing the following error in the IAM console when they have added a U2F device their gds-users IAM user:

no identity-based policy allows the iam:GetMFADevice action

This is happening because the `self_manage_iam_user` policy that is attached to each user in gds-users does not permit the GetMFADevice API call [1], which the AWS console uses to display details about the FIDO/U2F device. Note, it is not impacting the ability to add or use U2F devices for authentication, only its display in the console.

Fix this by adding the `iam:GetMFADevice` action to the `self_manage_iam_user` policy. This will only allow users to get details about their own U2F devices because it is limited to the user's IAM user ARN.

This is taken from AWS's own example IAM self-manage policy [2].

1. https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/get-mfa-device.html
2. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_iam_mfa-selfmanage.html

A screenshot of the error users are seeing in the console is:

<img width="1110" alt="mfa-get-mfadevice-error" src="https://github.com/alphagov/aws-user-management-account/assets/4644284/542ed1f8-e668-4a5c-9abb-707a5e3c4cb0">

However, with this change applied the console shows:

<img width="1108" alt="mfa-good" src="https://github.com/alphagov/aws-user-management-account/assets/4644284/c16545fb-ad4f-40fb-9b8b-822b21ecd8fc">
