### PR TITLE
eng-1092-iam-error-creating-aws-access-keys

### DIFF
--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -32,6 +32,9 @@ data "aws_iam_policy_document" "self_manage_iam_user" {
       "iam:*LoginProfile",
       "iam:*AccessKey*",
       "iam:*SSHPublicKey*",
+      "iam:ListUserTags",
+      "iam:UntagUser",
+      "iam:TagUser",
     ]
 
     resources = [


### PR DESCRIPTION
Users see an error saying they are missing this
permission when they create AWS access keys with
a description.